### PR TITLE
Fixed pdf-utils Password Protection example JSON.

### DIFF
--- a/docs/pdf-utils.md
+++ b/docs/pdf-utils.md
@@ -351,7 +351,7 @@ The pdf encryption can be set through jsreport studio and also through API call.
     "pdfPassword": {
        "password": "password",
        "ownerPassword": "password",
-       "printing": "HighResolution",
+       "printing": "highResolution",
 	   "modifying": true,
 	   "copying": true,
 	   "annotating" true,


### PR DESCRIPTION
Hey,

Just fixed something which tripped me up. The 'pdfPassword.printing' field in the example JSON for pdf-utils Password Protection had a value of 'HighResolution' instead of 'highResolution'.

Thanks