### PR TITLE
Rename resp to result

### DIFF
--- a/docs/adapting-jsreport.md
+++ b/docs/adapting-jsreport.md
@@ -38,7 +38,7 @@ const result = await jsreport.render({
 		foo: "world"
 	}
 })
-await fs.writeFile('report.pdf', resp.content)
+await fs.writeFile('report.pdf', result.content)
 ```
 
 ## Running without web server


### PR DESCRIPTION
**WHAT**
Make the example from the documentation workable.

**HOW**
Rename `resp` variable to `result`